### PR TITLE
Auth checks for delete and update user

### DIFF
--- a/src/main/java/se/java/security/controllers/UserController.java
+++ b/src/main/java/se/java/security/controllers/UserController.java
@@ -5,11 +5,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+import se.java.security.models.Listing;
 import se.java.security.models.User;
 import se.java.security.repository.UserRepository;
 import se.java.security.services.UserService;
-
+import se.java.security.util.JwtUtil;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/user")
@@ -17,10 +19,12 @@ public class UserController {
 
     private final UserService userService;
     private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
 
-    public UserController(UserService userService, UserRepository userRepository) {
+    public UserController(UserService userService, UserRepository userRepository, JwtUtil jwtUtil) {
         this.userService = userService;
         this.userRepository = userRepository;
+        this.jwtUtil = jwtUtil;
     }
 
     // list all user objects
@@ -44,34 +48,55 @@ public class UserController {
         return ResponseEntity.ok(user);
     }
 
-    // update user details
-    @PutMapping("/{id}")
-    public ResponseEntity<?> updateUser(@PathVariable String id, @Valid @RequestBody User userDetails) {
-        // check if user id exists, or throw
-        User existingUser = userRepository.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+    @PutMapping("/update")
+    public ResponseEntity<?> updateUser(@Valid @RequestBody User userDetails, @RequestHeader("Authorization") String token) {
+        String username = extractUsernameFromToken(token);
 
-        // change user details
+        if (username == null || username.isEmpty()) {
+            return ResponseEntity.status(401).body("Login expired, please log in again to update this user");
+        }
+
+        Optional<User> existingUserOptional = userRepository.findByUsername(username);
+        if (existingUserOptional.isEmpty()) {
+            return ResponseEntity.status(404).body("User " + username + " was not found");
+        }
+
+        User existingUser = existingUserOptional.get();
+        if (!existingUser.getId().equals(userRepository.findByUsername(username).get().getId())) {
+            return ResponseEntity.status(403).body("You are not allowed to update this user");
+        }
+
         existingUser.setUsername(userDetails.getUsername());
-        existingUser.setPassword(userDetails.getPassword());
         existingUser.setEmail(userDetails.getEmail());
+        existingUser.setFirstName(userDetails.getFirstName());
+        existingUser.setAge(userDetails.getAge());
 
-        // return values of the user object
         return ResponseEntity.ok(userRepository.save(existingUser));
     }
 
     // delete a user object
-    @DeleteMapping("/{id}")
-    public ResponseEntity<?> deleteUser(@PathVariable String id) {
-        // check if user id exists, or throw
-        if(!userRepository.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<?> deleteUser(@RequestHeader("Authorization") String token) {
+        String username = extractUsernameFromToken(token);
+        if (username == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid or expired token, please log in again");
         }
 
-        // delete the object
-        userRepository.deleteById(id);
+        Optional<User> userToDeleteOptional = userRepository.findByUsername(username);
+        if (userToDeleteOptional.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("User " + username + " was not found");
+        }
 
-        // return no values
+        userRepository.delete(userToDeleteOptional.get());
         return ResponseEntity.noContent().build();
+    }
+
+    private String extractUsernameFromToken(String token) {
+        try {
+            return jwtUtil.extractUsername(token.substring(7));
+        } catch (Exception e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Added @RequestHeader for deleting and updating a user
This forces a user to be logged in to make an action and only on themselves.
Makes Postman endpoints better and safer